### PR TITLE
Updating link to CWE Top 25 Most Dangerous Software Weaknesses

### DIFF
--- a/yellow/security-code-review.md
+++ b/yellow/security-code-review.md
@@ -24,6 +24,6 @@ The following areas of code tend to have a high-risk of containing security vuln
 
 ## Further Readings
 
-- Literature: [CWE Top 25 Most Dangerous Software Weaknesses](https://cwe.mitre.org/top25/archive/2020/2020_cwe_top25.html)
+- Literature: [CWE Top 25 Most Dangerous Software Weaknesses](https://cwe.mitre.org/top25/index.html)
 
 <p align="right"><a href="https://www.surveymonkey.de/r/MNWNVRB">Send Feedback</a></p>


### PR DESCRIPTION
The old link points to a 2020 version of the Top 25 list. The link in this PR points to CWE Top 25 home page, which will always be up to date.